### PR TITLE
Fix some of the incompatibility with openobex 1.7 and kill warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp/**
 __pycache__/**
 web/node_modules/**
 web/settings.js
+*.o


### PR DESCRIPTION
Since `openobex 1.6`, `obex_FindInterfaces` got split into two other methods.

I've also fixed a bunch of warnings generated by the compiler.